### PR TITLE
Configure DuckDB to read data from MinIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ In the minio UI, use `minio`, and `minio123` as username and password respective
 
 # Analyze data with duckDB
 
+## Access the data in minio via filesystem
 We [mount a local folder to minio container](./docker-compose.yml) which allows us to access the data in minio via filesystem. We can start a Python REPL to run DuckDB as shown below:
 
 ```bash
@@ -123,13 +124,16 @@ d.sql("""
     """).execute()
 ```
 
+## Access data via s3 api
+We can also access the data via the S3 API in duckdb as shown in this [example SQL query](./example/duckdb_minio_product_scd2.sql).
+
 # References
 
 1. [Debezium postgre docs](https://debezium.io/documentation/reference/2.1/connectors/postgresql.html)
 2. [Redpanda CDC example](https://redpanda.com/blog/redpanda-debezium)
 3. [duckDB docs](https://duckdb.org/docs/archive/0.2.9/)
 4. [Kafka docs](https://kafka.apache.org/20/documentation.html)
-
+5. [Minio DuckDB example](https://blog.min.io/duckdb-and-minio-for-a-modern-data-stack/)
 
 <!-- Send message to kafka
 CASE WHEN LEAD(source_timestamp, 1) OVER(PARTITION BY id ORDER BY log_seq_num ) IS NULL THEN CAST('9999-01-01' AS TIMESTAMP) ELSE 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,8 @@ services:
   createbuckets:
     image: minio/mc
     container_name: createbuckets
+    links:
+      - minio:minio
     depends_on:
       - minio
     entrypoint: >

--- a/example/duckdb_minio_product_scd2.sql
+++ b/example/duckdb_minio_product_scd2.sql
@@ -1,0 +1,47 @@
+-- Minio ignores the region so you can use any region name over here
+SET s3_region='us-east-1';
+SET s3_url_style='path';
+-- Set this endpoint to where minio is at
+-- if you are following the blog leave the endpoint as it is
+SET s3_endpoint='localhost:9000';
+-- this is your minio username
+SET s3_access_key_id='minio' ;
+-- this is your minio password
+SET s3_secret_access_key='minio123';
+SET s3_use_ssl=false;
+WITH products_create_update_delete AS (
+SELECT
+    COALESCE(CAST(json->'value'->'after'->'id' AS INT), CAST(json->'value'->'before'->'id' AS INT)) AS id,
+        json->'value'->'before' AS before_row_value,
+        json->'value'->'after' AS after_row_value,
+        CASE
+            WHEN CAST(json->'value'->'$.op' AS CHAR(1)) = '"c"' THEN 'CREATE'
+            WHEN CAST(json->'value'->'$.op' AS CHAR(1)) = '"d"' THEN 'DELETE'
+            WHEN CAST(json->'value'->'$.op' AS CHAR(1)) = '"u"' THEN 'UPDATE'
+            WHEN CAST(json->'value'->'$.op' AS CHAR(1)) = '"r"' THEN 'SNAPSHOT'
+            ELSE 'INVALID'
+        END AS operation_type,
+        CAST(json->'value'->'source'->'lsn' AS BIGINT) AS log_seq_num,
+        epoch_ms(CAST(json->'value'->'source'->'ts_ms' AS BIGINT)) AS source_timestamp
+    FROM
+        read_ndjson_objects('s3://commerce/debezium.commerce.products/*/*/*.json')
+    WHERE
+        log_seq_num IS NOT NULL
+)
+SELECT
+    id,
+    CAST(after_row_value->'name' AS VARCHAR(255)) AS name,
+    CAST(after_row_value->'description' AS TEXT) AS description,
+    CAST(after_row_value->'price' AS NUMERIC(10, 2)) AS price,
+    source_timestamp AS row_valid_start_timestamp,
+    -- LEAD(source_timestamp , 1) OVER lead_txn_timestamp AS row_valid_end_timestamp
+    CASE 
+        WHEN LEAD(source_timestamp, 1) OVER lead_txn_timestamp IS NULL THEN CAST('9999-01-01' AS TIMESTAMP) 
+        ELSE LEAD(source_timestamp, 1) OVER lead_txn_timestamp 
+    END AS row_valid_expiration_timestamp
+FROM products_create_update_delete
+WHERE id in (SELECT id FROM products_create_update_delete GROUP BY id HAVING COUNT(*) > 1)
+WINDOW lead_txn_timestamp AS (PARTITION BY id ORDER BY log_seq_num )
+ORDER BY id, row_valid_start_timestamp
+LIMIT
+    200;


### PR DESCRIPTION
I added an example query on how to connect and read the data in the minio bucket using the S3 API endpoint. 

I also noticed that the `createbuckets` container would never create the commerce bucket on start-up. 